### PR TITLE
Improve PiLisp Stack Traces

### DIFF
--- a/lib/src/pilisp_env.dart
+++ b/lib/src/pilisp_env.dart
@@ -29,8 +29,11 @@ class PLEnv {
   /// Methods pretty-print by default, using [indentSize] spaces to indent.
   int indentSize = 2;
 
-  /// When set to true, print PiLisp stack traces in addition to Dart ones.
+  /// When set to true, print PiLisp stack traces.
   bool printStackTraces = true;
+
+  /// When set to true, print Dart stack traces.
+  bool printDartStackTraces = true;
 
   /// The names of the frames of the stack.
   List<String> stackFrames = [];
@@ -562,16 +565,20 @@ class PLEnv {
     return false;
   }
 
-  void pushStackFrame(PLSymbol frameName) {
-    stackFrames.add(frameName.toString());
+  void pushStackFrame(String frameName) {
+    stackFrames.add(frameName);
   }
 
   void popStackFrame() {
     stackFrames.removeLast();
   }
 
-  List<String> currentStackTrace() {
-    return stackFrames.map((e) => 'fn: $e').toList();
+  Iterable<String> currentStackTrace() {
+    return PLEnv.formatStackTrace(stackFrames);
+  }
+
+  static Iterable<String> formatStackTrace(List<String> frames) {
+    return frames.reversed.map((e) => 'fn: $e');
   }
 
   String currentIndentation() => ' ' * (indentSize * indentIndex);

--- a/lib/src/pilisp_env.dart
+++ b/lib/src/pilisp_env.dart
@@ -29,11 +29,9 @@ class PLEnv {
   /// Methods pretty-print by default, using [indentSize] spaces to indent.
   int indentSize = 2;
 
-  /// When set to true, print PiLisp stack traces.
+  /// When set to true, print PiLisp stack traces. Set [isDebug] to `true` to
+  /// print Dart stack traces.
   bool printStackTraces = true;
-
-  /// When set to true, print Dart stack traces.
-  bool printDartStackTraces = true;
 
   /// The names of the frames of the stack.
   List<String> stackFrames = [];

--- a/lib/src/pilisp_error.dart
+++ b/lib/src/pilisp_error.dart
@@ -1,3 +1,5 @@
+import 'package:pilisp/src/pilisp_public.dart';
+
 import 'pilisp_expr.dart';
 
 class UndefinedSymbol implements Exception {
@@ -90,5 +92,34 @@ class UnsupportedEscapeCharacter extends PiLispReaderException {
   @override
   String toString() {
     return '$runtimeType: $message';
+  }
+}
+
+class PLInvocationException implements Exception {
+  /// Dart allows throwing any value, so this is [Object].
+  final Object thrown;
+
+  /// The [PLEnv] Stack frames are popped such that they are not available when
+  /// trying to print them up/downstream. This field should be a copy of the
+  /// [PLEnv.stackFrames] at the time the underlying [thrown] is caught.
+  final List<String> stackFrames;
+
+  PLInvocationException(this.thrown, this.stackFrames);
+
+  @override
+
+  /// Make this exception opaque to the end-user by rendering its string value
+  /// like the [thrown] object.
+  String toString() {
+    return '#<PLInvocationException<${thrown.toString()}>>';
+  }
+
+  /// Returns the [thrown] of the innermost [PLInvocationException].
+  Object rootCause() {
+    if (thrown is PLInvocationException) {
+      final t = thrown as PLInvocationException;
+      return t.rootCause();
+    }
+    return thrown;
   }
 }

--- a/lib/src/pilisp_expr.dart
+++ b/lib/src/pilisp_expr.dart
@@ -201,10 +201,7 @@ class PLTerm extends PLExpr implements PLInvocable {
 }
 
 class PLException extends PLExpr implements Exception {
-  Iterable<String>? _stackTrace;
-  bool isThrown = false;
   String message;
-  String _stackTraceMessage = '';
   IMap<Object?, Object?> data = IMap<Object?, Object?>({});
 
   PLException(this.message);
@@ -225,26 +222,9 @@ class PLException extends PLExpr implements Exception {
     return 'exception';
   }
 
-  Iterable<String> get stackTrace => _stackTrace ?? [];
-
-  void saveStackTrace(PLEnv env, Object? topLevelForm) {
-    final st = env.currentStackTrace();
-    String msg = '';
-    if (st.isNotEmpty) {
-      msg = st.toList().reversed.map((e) => '  from $e').join('\n');
-    }
-    final topLevel =
-        'Thrown from expression:\n${plPrintToString(env, topLevelForm)}';
-    msg = msg.isEmpty ? topLevel : '$topLevel\n$msg';
-    _stackTraceMessage = msg;
-    _stackTrace = st;
-  }
-
   @override
   String toString() {
-    String msg = 'PiLisp Exception: $message';
-    msg += _stackTraceMessage.isEmpty ? '' : '\n$_stackTraceMessage';
-    return msg;
+    return '#<PLException: $message>';
   }
 }
 
@@ -557,10 +537,8 @@ class PLList extends PLExprIterable
               'The throw special form expects a single exception value, but encountered ${length - 1} arguments.');
         }
         final exception = plEval(env, this[1]);
+        // TODO Consider allowing throwing any value, since Dart supports that.
         if (exception is PLException) {
-          // NB: What was this boolean for?
-          exception.isThrown = true;
-          exception.saveStackTrace(env, this);
           throw exception;
         } else {
           throw FormatException(

--- a/lib/src/pilisp_public.dart
+++ b/lib/src/pilisp_public.dart
@@ -70,10 +70,10 @@ class PiLisp {
         frames = ev.currentStackTrace();
       }
       if (frames.isNotEmpty) {
-        print(frames.join('  \n'));
+        print('  ${frames.join('\n  ')}');
       }
     }
-    if (ev.printDartStackTraces && stackTrace != null) {
+    if (ev.isDebug && stackTrace != null) {
       print(stackTrace);
     }
     if (expr is PLList) {

--- a/lib/src/pilisp_public.dart
+++ b/lib/src/pilisp_public.dart
@@ -55,20 +55,33 @@ class PiLisp {
   /// some PiLisp code), evaluate it and return the resulting value.
   static Object? eval(Object expr, {PLEnv? env}) {
     final ev = env ?? piLispEnv;
-    try {
-      return plEval(ev, expr);
-    } catch (e) {
-      if (expr is PLList) {
-        if (expr.loc != null) {
-          final id = ev.nextId();
-          print('($id) Error on line ${expr.loc}');
-          print('($id) Form:\n${plPrintToString(ev, expr)}');
-        }
+    return plEval(ev, expr);
+  }
+
+  static void logEvalException(Object? expr, Object? exception,
+      {PLEnv? env, StackTrace? stackTrace}) {
+    final ev = env ?? piLispEnv;
+    print(exception);
+    if (ev.printStackTraces) {
+      Iterable<String> frames;
+      if (exception is PLInvocationException) {
+        frames = PLEnv.formatStackTrace(exception.stackFrames);
+      } else {
+        frames = ev.currentStackTrace();
       }
-      if (ev.printStackTraces) {
-        print(ev.currentStackTrace());
+      if (frames.isNotEmpty) {
+        print(frames.join('  \n'));
       }
-      rethrow;
+    }
+    if (ev.printDartStackTraces && stackTrace != null) {
+      print(stackTrace);
+    }
+    if (expr is PLList) {
+      if (expr.loc != null) {
+        final id = ev.nextId();
+        print('($id) Error on line ${expr.loc}');
+        print('($id) Form:\n${plPrintToString(ev, expr)}');
+      }
     }
   }
 
@@ -76,14 +89,7 @@ class PiLisp {
   /// final one.
   static Object? loadString(String programSource, {PLEnv? env}) {
     final ev = env ?? piLispEnv;
-    try {
-      return plLoad(env ?? piLispEnv, programSource);
-    } catch (e) {
-      if (ev.printStackTraces) {
-        print(ev.currentStackTrace());
-      }
-      rethrow;
-    }
+    return plLoad(ev, programSource);
   }
 
   /// Returns a string of the given [value] as a readable PiLisp form.


### PR DESCRIPTION
Before this PR's changes, PiLisp printed Dart stack traces, but the ones consisting of PiLisp invocations tracked via the active `PLEnv` have not been working for some time.

This PR fixes them.

The defaults of `PLEnv` and the public-facing `PiLisp` class still have both PiLisp and Dart stack traces printing by default.

Work that I'd like to finish before merging this PR:

- [x] Make configurable at runtime whether Dart stack traces print.
- [x] By default, do not print Dart stack traces.

Work that falls outside the scope of this PR: (a) getting better line/column information into the output of stack traces.